### PR TITLE
[ofono2mm] PolicyKit: Allow users inside the 'radio' group to control ModemManager interfaces

### DIFF
--- a/debian/ofono2mm.dirs
+++ b/debian/ofono2mm.dirs
@@ -1,3 +1,4 @@
 /usr/bin
 /usr/lib/ofono2mm
 /lib/systemd/system/ModemManager.service.d
+/etc/polkit-1/localauthority/10-vendor.d

--- a/debian/ofono2mm.install
+++ b/debian/ofono2mm.install
@@ -4,3 +4,4 @@ ofono.xml /usr/lib/ofono2mm
 ofono_modem.xml /usr/lib/ofono2mm
 ofono_operator.xml /usr/lib/ofono2mm
 systemd/10-ofono2mm.conf /lib/systemd/system/ModemManager.service.d/
+extra/ofono2mm-radio.pkla /etc/polkit-1/localauthority/10-vendor.d/

--- a/extra/ofono2mm-radio.pkla
+++ b/extra/ofono2mm-radio.pkla
@@ -1,0 +1,4 @@
+[Allow org.freedesktop.ModemManager1 on users inside the radio group]
+Identity=unix-group:radio
+Action=org.freedesktop.ModemManager1.Device.Control;org.freedesktop.ModemManager1.Contacts;org.freedesktop.ModemManager1.Messaging;org.freedesktop.ModemManager1.Location
+ResultActive=yes


### PR DESCRIPTION
This should resolve the 'Access Denied' issue.

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>