### PR TITLE
wire up more signals and indicators

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,5 +16,6 @@ Depends: ${misc:Depends},
 	 python3-dbus-next,
 	 python3-gi,
 	 modemmanager,
-	 geoclue-2.0
+	 geoclue-2.0,
+	 gir1.2-geoclue-2.0
 Description: A simple python script implementing ModemManager DBus API and using ofono to manage the modem

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -36,7 +36,7 @@ class MMModemInterface(ServiceInterface):
         self.ofono_props = {}
         self.ofono_interfaces = {}
         self.ofono_interface_props = {}
-        self.mm_cell_type = 0
+        self.mm_cell_type = 0 # on runtime unknown MM_CELL_TYPE_UNKNOWN
         self.mm_modem3gpp_interface = False
         self.mm_modem_messaging_interface = False
         self.mm_sim_interface = False
@@ -473,16 +473,31 @@ class MMModemInterface(ServiceInterface):
                 current_tech = 0
                 if self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "nr":
                     current_tech |= 1 << 15 # network is 5g MM_MODEM_ACCESS_TECHNOLOGY_5GNR
-                    self.mm_cell_type = 6
+                    self.mm_cell_type = 6 # cell type is 5g MM_CELL_TYPE_5GNR
                 elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "lte":
                     current_tech |= 1 << 14 # network is lte MM_MODEM_ACCESS_TECHNOLOGY_LTE
-                    self.mm_cell_type = 5
-                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "umts" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hspa" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsdpa" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsupa":
+                    self.mm_cell_type = 5 # cell type is lte MM_CELL_TYPE_LTE
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hspa":
+                    current_tech |= 1 << 8 # network is hspa MM_MODEM_ACCESS_TECHNOLOGY_HSPA
+                    self.mm_cell_type = 3 # cell type is umts MM_CELL_TYPE_UMTS
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsupa":
+                    current_tech |= 1 << 7 # network is hsupa MM_MODEM_ACCESS_TECHNOLOGY_HSUPA
+                    self.mm_cell_type = 3 # cell type is umts MM_CELL_TYPE_UMTS
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsdpa":
+                    current_tech |= 1 << 6 # network is hsdpa MM_MODEM_ACCESS_TECHNOLOGY_HSDPA
+                    self.mm_cell_type = 3 # cell type is umts MM_CELL_TYPE_UMTS
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "umts":
                     current_tech |= 1 << 5 # network is umts MM_MODEM_ACCESS_TECHNOLOGY_UMTS
-                    self.mm_cell_type = 3
-                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gsm" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "edge" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gprs":
+                    self.mm_cell_type = 3 # cell type is umts MM_CELL_TYPE_UMTS
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "edge":
+                    current_tech |= 1 << 4 # network is gsm MM_MODEM_ACCESS_TECHNOLOGY_GSM
+                    self.mm_cell_type = 2 # cell type is gsm MM_CELL_TYPE_GSM
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gprs":
+                    current_tech |= 1 << 3 # network is gsm MM_MODEM_ACCESS_TECHNOLOGY_GSM
+                    self.mm_cell_type = 2 # cell type is gsm MM_CELL_TYPE_GSM
+                elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gsm":
                     current_tech |= 1 << 1 # network is gsm MM_MODEM_ACCESS_TECHNOLOGY_GSM
-                    self.mm_cell_type = 2
+                    self.mm_cell_type = 2 # cell type is gsm MM_CELL_TYPE_GSM
 
                 self.props['AccessTechnologies'] = Variant('u', current_tech)
             else:

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -173,6 +173,9 @@ class MMModemInterface(ServiceInterface):
         self.mm_modem_time_interface = MMModemTimeInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props)
         self.bus.export(f'/org/freedesktop/ModemManager1/Modem/{self.index}', self.mm_modem_time_interface)
 
+        if 'org.ofono.NetworkTime' in self.ofono_interfaces:
+            await self.mm_modem_time_interface.init_time()
+
     async def init_mm_cdma_interface(self):
         self.mm_modem_cdma_interface = MMModemCDMAInterface(self)
         self.bus.export(f'/org/freedesktop/ModemManager1/Modem/{self.index}', self.mm_modem_cdma_interface)

--- a/ofono2mm/mm_modem_voice.py
+++ b/ofono2mm/mm_modem_voice.py
@@ -33,6 +33,11 @@ class MMModemVoiceInterface(ServiceInterface):
                 self.emit_properties_changed({prop: self.props[prop].value})
 
     async def init_calls(self):
+        if 'org.ofono.SimManager' in self.ofono_interfaces and 'FixedDialing' in self.ofono_interface_props['org.ofono.SimManager']:
+            self.props['EmergencyOnly'] = Variant('b', self.ofono_interface_props['org.ofono.SimManager']['FixedDialing'].value)
+        else:
+            self.props['EmergencyOnly'] = Variant('b', False)
+
         if 'org.ofono.VoiceCallManager' in self.ofono_interfaces:
             self.ofono_interfaces['org.ofono.VoiceCallManager'].on_call_added(self.add_call)
 
@@ -42,6 +47,12 @@ class MMModemVoiceInterface(ServiceInterface):
     async def add_call(self, path, props):
         if props['State'].value == 'incoming':
             global call_i
+
+            if 'org.ofono.SimManager' in self.ofono_interfaces and 'FixedDialing' in self.ofono_interface_props['org.ofono.SimManager']:
+                self.props['EmergencyOnly'] = Variant('b', self.ofono_interface_props['org.ofono.SimManager']['FixedDialing'].value)
+            else:
+                self.props['EmergencyOnly'] = Variant('b', False)
+
             mm_call_interface = MMCallInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props)
             mm_call_interface.props.update({
                 'State': Variant('u', 3), # ringing in MM_CALL_STATE_RINGING_IN
@@ -70,6 +81,11 @@ class MMModemVoiceInterface(ServiceInterface):
             self.CallDeleted(f'/org/freedesktop/ModemManager1/Call/{call_i}')
         except Exception as e:
             pass
+
+        if 'org.ofono.SimManager' in self.ofono_interfaces and 'FixedDialing' in self.ofono_interface_props['org.ofono.SimManager']:
+            self.props['EmergencyOnly'] = Variant('b', self.ofono_interface_props['org.ofono.SimManager']['FixedDialing'].value)
+        else:
+            self.props['EmergencyOnly'] = Variant('b', False)
 
         # print(f"call deleted: {path}")
         if 'org.ofono.ConnectionManager' in self.ofono_interfaces:
@@ -111,9 +127,19 @@ class MMModemVoiceInterface(ServiceInterface):
             self.emit_properties_changed({'Calls': self.props['Calls'].value})
             self.CallDeleted(path)
 
+            if 'org.ofono.SimManager' in self.ofono_interfaces and 'FixedDialing' in self.ofono_interface_props['org.ofono.SimManager']:
+                self.props['EmergencyOnly'] = Variant('b', self.ofono_interface_props['org.ofono.SimManager']['FixedDialing'].value)
+            else:
+                self.props['EmergencyOnly'] = Variant('b', False)
+
     @method()
     async def CreateCall(self, properties: 'a{sv}') -> 'o':
         global call_i
+
+        if 'org.ofono.SimManager' in self.ofono_interfaces and 'FixedDialing' in self.ofono_interface_props['org.ofono.SimManager']:
+            self.props['EmergencyOnly'] = Variant('b', self.ofono_interface_props['org.ofono.SimManager']['FixedDialing'].value)
+        else:
+            self.props['EmergencyOnly'] = Variant('b', False)
 
         mm_call_interface = MMCallInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props)
         mm_call_interface.props.update({

--- a/ofono_modem.xml
+++ b/ofono_modem.xml
@@ -522,8 +522,6 @@
 	    </method>
 	</interface>
 
-	<node name="cell_42"/>
-	<node name="cell_44"/>
 	<node name="context1"/>
 	<node name="context2"/>
 	<node name="context3"/>


### PR DESCRIPTION
set modem emergency state from fixed dialing of ofono
show different indicators for different gsm and umts modes (such as edge gprs hspa etc)
add git1.2-geoclue-2.0 as a runtime dependency. it was pulled in by gnome weather but in other desktop environments it doesn't exist
wire up NetworkTimeChanged for carrier NTP updates to keep the bus up to date