### PR TITLE
systemd: Wait for ofono

### DIFF
--- a/systemd/10-ofono2mm.conf
+++ b/systemd/10-ofono2mm.conf
@@ -4,6 +4,7 @@
 Requires=ofono.service
 
 [Service]
+ExecStartPre=/usr/bin/gdbus wait -y org.ofono
 ExecStart=
 ExecStart=/usr/bin/ofono2mm
 StandardOutput=journal


### PR DESCRIPTION
ModemManager is started after ofono but DBus name may not be ready yet.

This patch use gdbus to wait for ofono bus.

