### PR TITLE
Draft: nm_modem: Locked SIM card does not imply locked modem

### DIFF
--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -356,7 +356,7 @@ class MMModemInterface(ServiceInterface):
                         self.props['UnlockRequired'] = Variant('u', 1) # modem is unlocked MM_MODEM_LOCK_NONE
                     else:
                         self.props['UnlockRequired'] = Variant('u', 2) # modem needs a pin MM_MODEM_LOCK_SIM_PIN
-                        self.props['State'] = Variant('i', 2)
+                        self.props['State'] = Variant('i', 3) # modem is disabled MM_MODEM_STATE_DISABLED
 
                     self.props['Sim'] = self.sim
                     self.props['StateFailedReason'] = Variant('i', 0) # no failure MM_MODEM_STATE_FAILED_REASON_NONE


### PR DESCRIPTION
MM_MODEM_STATE_LOCKED is related to LockDown Ofono property.

This fix an issue preventing NetworkManager from enabling/onlining the modem.

`mai 31 17:59:47 RedmiNote9Pro NetworkManager[996]: <warn>  [1717171187.2279] modem["/ril_0"]: cannot enable/disable modem: locked`
