### PR TITLE
Continue cleanup work

### DIFF
--- a/ofono2mm/mm_bearer.py
+++ b/ofono2mm/mm_bearer.py
@@ -3,6 +3,7 @@ from dbus_next.service import (ServiceInterface,
 from dbus_next.constants import PropertyAccess
 from dbus_next import Variant, DBusError, BusType
 
+from ofono2mm.mm_types import ModemManagerPortType
 from ofono2mm.utils import async_retryable
 
 import asyncio
@@ -207,7 +208,7 @@ class MMBearerInterface(ServiceInterface):
                 self.props['Interface'] = value.value['Interface']
                 self.emit_properties_changed({'Interface': value.value['Interface'].value})
                 if [value.value['Interface'].value, 2] not in self.mm_modem.props['Ports'].value:
-                    self.mm_modem.props['Ports'].value.append([value.value['Interface'].value, 2]) # port type AT MM_MODEM_PORT_TYPE_AT
+                    self.mm_modem.props['Ports'].value.append([value.value['Interface'].value, ModemManagerPortType.AT])
             if 'Method' in value.value:
                 if value.value['Method'].value == 'static':
                     self.props['Ip4Config'].value['method'] = Variant('u', 2) # static MM_BEARER_IP_METHOD_STATIC

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -25,6 +25,7 @@ from ofono2mm.mm_types import ModemManagerState,\
                               ModemManagerCellType,\
                               ModemManagerMode,\
                               ModemManagerCapability,\
+                              ModemManagerPortType,\
                               OFONO_TECHNOLOGIES,\
                               OFONO_CELL_TYPES,\
                               OFONO_RETRIES_LOCK,\
@@ -78,7 +79,7 @@ class MMModemInterface(ServiceInterface):
             'Drivers': Variant('as', ['binder']),
             'Plugin': Variant('s', 'ofono2mm'),
             'PrimaryPort': Variant('s', self.modem_name),
-            'Ports': Variant('a(su)', [[self.modem_name, 0]]), # on runtime unknown MM_MODEM_PORT_TYPE_UNKNOWN
+            'Ports': Variant('a(su)', [[self.modem_name, ModemManagerPortType.UNKNOWN]]),
             'EquipmentIdentifier': Variant('s', ''),
             'UnlockRequired': Variant('u', ModemManagerLock.UNKNOWN),
             'UnlockRetries': Variant('a{uu}', {}),
@@ -272,7 +273,7 @@ class MMModemInterface(ServiceInterface):
                 })
 
                 if 'Interface' in ctx[1]['Settings'].value:
-                    self.props['Ports'].value.append([ctx[1]['Settings'].value['Interface'].value, 2]) # port type AT MM_MODEM_PORT_TYPE_AT
+                    self.props['Ports'].value.append([ctx[1]['Settings'].value['Interface'].value, ModemManagerPortType.AT])
                     self.emit_properties_changed({'Ports': self.props['Ports'].value})
 
                 ofono_ctx_interface = self.ofono_client["ofono_context"][ctx[0]]["org.ofono.ConnectionContext"]

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -18,233 +18,24 @@ from ofono2mm.mm_modem_location import MMModemLocationInterface
 from ofono2mm.mm_sim import MMSimInterface
 from ofono2mm.mm_bearer import MMBearerInterface
 from ofono2mm.mm_modem_voice import MMModemVoiceInterface
+from ofono2mm.mm_types import ModemManagerState,\
+                              ModemManagerStateFailedReason,\
+                              ModemManagerLock,\
+                              ModemManagerAccessTechnology,\
+                              ModemManagerCellType,\
+                              ModemManagerMode,\
+                              ModemManagerCapability,\
+                              OFONO_TECHNOLOGIES,\
+                              OFONO_CELL_TYPES,\
+                              OFONO_RETRIES_LOCK,\
+                              OFONO_MODES,\
+                              OFONO_CAPS,\
+                              MM_MODES
 from ofono2mm.logger import Logger
 
 import asyncio
 
 bearer_i = 0
-
-class ModemManagerState:
-    FAILED        = -1
-    UNKNOWN       = 0
-    INITIALIZING  = 1
-    LOCKED        = 2
-    DISABLED      = 3
-    DISABLING     = 4
-    ENABLING      = 5
-    ENABLED       = 6
-    SEARCHING     = 7
-    REGISTERED    = 8
-    DISCONNECTING = 9
-    CONNECTING    = 10
-    CONNECTED     = 11
-
-    def to_string(value):
-        match value:
-            case ModemManagerState.FAILED:
-                return "Failed"
-            case ModemManagerState.UNKNOWN:
-                return "Unknown"
-            case ModemManagerState.INITIALIZING:
-                return "Initializing"
-            case ModemManagerState.LOCKED:
-                return "Locked"
-            case ModemManagerState.DISABLED:
-                return "Disabled"
-            case ModemManagerState.DISABLING:
-                return "Disabling"
-            case ModemManagerState.ENABLING:
-                return "Enabling"
-            case ModemManagerState.ENABLED:
-                return "Enabled"
-            case ModemManagerState.SEARCHING:
-                return "Searching"
-            case ModemManagerState.REGISTERED:
-                return "Registered"
-            case ModemManagerState.DISCONNECTING:
-                return "Disconnecting"
-            case ModemManagerState.CONNECTING:
-                return "Connecting"
-            case _:
-                return "Connected"
-
-class ModemManagerStateFailedReason:
-    NONE                  = 0
-    UNKNOWN               = 1
-    SIM_MISSING           = 2
-    SIM_ERROR             = 3
-    UNKNOWN_CAPABILITIES  = 4
-    ESIM_WITHOUT_PROFILES = 5
-
-class ModemManagerLock:
-    UNKNOWN        = 0
-    NONE           = 1
-    SIM_PIN        = 2
-    SIM_PIN2       = 3
-    SIM_PUK        = 4
-    SIM_PUK2       = 5
-    PH_SP_PIN      = 6
-    PH_SP_PUK      = 7
-    PH_NET_PIN     = 8
-    PH_NET_PUK     = 9
-    PH_SIM_PIN     = 10
-    PH_CORP_PIN    = 11
-    PH_CORP_PUK    = 12
-    PH_FSIM_PIN    = 13
-    PH_FSIM_PUK    = 14
-    PH_NETSUB_PIN  = 15
-    PH_NETSUB_PUK  = 16
-
-OFONO_RETRIES_LOCK = {
-    'pin' : ModemManagerLock.SIM_PIN,
-    'pin2': ModemManagerLock.SIM_PIN2,
-    'puk': ModemManagerLock.SIM_PUK,
-    'puk2': ModemManagerLock.SIM_PUK2,
-    'service': ModemManagerLock.PH_SP_PIN,
-    'servicepuk': ModemManagerLock.PH_SP_PUK,
-    'network': ModemManagerLock.PH_NET_PIN,
-    'networkpuk': ModemManagerLock.PH_NET_PUK,
-    'corp': ModemManagerLock.PH_CORP_PIN,
-    'corppuk': ModemManagerLock.PH_CORP_PUK,
-    'netsub': ModemManagerLock.PH_NETSUB_PIN,
-    'netsubpuk': ModemManagerLock.PH_NETSUB_PUK,
-}
-
-class ModemManagerAccessTechnology:
-    UNKNOWN     = 0
-    POTS        = 1 << 0
-    GSM         = 1 << 1
-    GSM_COMPACT = 1 << 2
-    GPRS        = 1 << 3
-    EDGE        = 1 << 4
-    UMTS        = 1 << 5
-    HSDPA       = 1 << 6
-    HSUPA       = 1 << 7
-    HSPA        = 1 << 8
-    HSPA_PLUS   = 1 << 9
-    _1XRTT      = 1 << 10
-    EVDO0       = 1 << 11
-    EVDOA       = 1 << 12
-    EVDOB       = 1 << 13
-    LTE         = 1 << 14
-    _5GNR       = 1 << 15
-    LTE_CAT_M   = 1 << 16
-    LTE_NB_IOT  = 1 << 17
-    ANY         = 0xFFFFFFFF
-
-class ModemManagerCellType:
-    UNKNOWN = 0
-    CDMA    = 1
-    GSM     = 2
-    UMTS    = 3
-    TDSCDMA = 4
-    LTE     = 5
-    _5GNR   = 6
-
-OFONO_TECHNOLOGIES = {
-    "nr": ModemManagerAccessTechnology._5GNR,
-    "lte": ModemManagerAccessTechnology.LTE,
-    "hspa": ModemManagerAccessTechnology.HSPA,
-    "hsupa": ModemManagerAccessTechnology.HSUPA,
-    "hsdpa": ModemManagerAccessTechnology.HSDPA,
-    "umts": ModemManagerAccessTechnology.UMTS,
-    "edge": ModemManagerAccessTechnology.GSM,
-    "gprs": ModemManagerAccessTechnology.GSM,
-    "gsm": ModemManagerAccessTechnology.GSM
-}
-
-OFONO_CELL_TYPES = {
-    "nr": ModemManagerCellType._5GNR,
-    "lte": ModemManagerCellType.LTE,
-    "hspa": ModemManagerCellType.UMTS,
-    "hsupa": ModemManagerCellType.UMTS,
-    "hsdpa": ModemManagerCellType.UMTS,
-    "umts": ModemManagerCellType.UMTS,
-    "edge": ModemManagerCellType.GSM,
-    "gprs": ModemManagerCellType.GSM,
-    "gsm": ModemManagerCellType.GSM
-}
-
-class ModemManagerMode:
-    NONE = 0
-    CS   = 1 << 0
-    _2G  = 1 << 1
-    _3G  = 1 << 2
-    _4G  = 1 << 3
-    _5G  = 1 << 4
-    ANY  = 0xFFFFFFFF
-
-class ModemManagerCapability:
-    NONE         = 0
-    POTS         = 1 << 0
-    CDMA_EVDO    = 1 << 1
-    GSM_UMTS     = 1 << 2
-    LTE          = 1 << 3
-    IRIDIUM      = 1 << 5
-    _5GNR        = 1 << 6
-    TDS          = 1 << 7
-    ANY          = 0xFFFFFFFF
-
-OFONO_MODES = {
-    "gsm": ModemManagerMode._2G,
-    "umts": ModemManagerMode._3G,
-    "lte": ModemManagerMode._4G,
-    "nr": ModemManagerMode._5G
-}
-
-OFONO_CAPS = {
-    "gsm": ModemManagerCapability.GSM_UMTS,
-    "umts": ModemManagerCapability.GSM_UMTS,
-    "lte": ModemManagerCapability.LTE,
-    "nr": ModemManagerCapability._5GNR
-}
-
-MM_MODES = {
-    ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G: [
-        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode._5G],
-        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
-        [ModemManagerMode._2G | ModemManagerMode._3G, ModemManagerMode._3G],
-        [ModemManagerMode._2G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G: [
-        [ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._2G | ModemManagerMode._4G | ModemManagerMode._5G: [
-        [ModemManagerMode._2G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._4G | ModemManagerMode._5G: [
-        [ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._3G | ModemManagerMode._5G: [
-        [ModemManagerMode._3G | ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._2G | ModemManagerMode._5G: [
-        [ModemManagerMode._2G | ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._5G: [
-        [ModemManagerMode._5G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G: [
-        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
-        [ModemManagerMode._2G | ModemManagerMode._3G, ModemManagerMode._3G],
-        [ModemManagerMode._2G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._3G | ModemManagerMode._4G: [
-        [ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
-        [ModemManagerMode._3G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._2G | ModemManagerMode._4G: [
-        [ModemManagerMode._2G | ModemManagerMode._4G, ModemManagerMode._4G],
-        [ModemManagerMode._2G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._3G: [
-        [ModemManagerMode._3G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode._2G: [
-        [ModemManagerMode._2G, ModemManagerMode.ANY]
-    ],
-    ModemManagerMode.NONE: []
-}
 
 class MMModemInterface(ServiceInterface):
     def __init__(self, loop, index, bus, ofono_client, modem_name):

--- a/ofono2mm/mm_modem_simple.py
+++ b/ofono2mm/mm_modem_simple.py
@@ -2,6 +2,8 @@ from dbus_next.service import (ServiceInterface, method, dbus_property, signal)
 from dbus_next.constants import PropertyAccess
 from dbus_next import Variant
 
+from ofono2mm.mm_types import ModemManagerState, ModemManagerAccessTechnology
+
 class MMModemSimpleInterface(ServiceInterface):
     def __init__(self, mm_modem, ofono_interfaces, ofono_interface_props):
         super().__init__('org.freedesktop.ModemManager1.Modem.Simple')
@@ -9,10 +11,10 @@ class MMModemSimpleInterface(ServiceInterface):
         self.ofono_interfaces = ofono_interfaces
         self.ofono_interface_props = ofono_interface_props
         self.props = {
-             'state': Variant('u', 7), # on runtime enabled MM_MODEM_STATE_ENABLED
+             'state': Variant('u', ModemManagerState.ENABLED),
              'signal-quality': Variant('(ub)', [0, True]),
              'current-bands': Variant('au', []),
-             'access-technologies': Variant('u', 0), # on runtime unknown MM_MODEM_ACCESS_TECHNOLOGY_UNKNOWN
+             'access-technologies': Variant('u', ModemManagerAccessTechnology.UNKNOWN),
              'm3gpp-registration-state': Variant('u', 0), # on runtime idle MM_MODEM_3GPP_REGISTRATION_STATE_IDLE
              'm3gpp-operator-code': Variant('s', ''),
              'm3gpp-operator-name': Variant('s', ''),
@@ -44,11 +46,11 @@ class MMModemSimpleInterface(ServiceInterface):
 
             if 'Status' in self.ofono_interface_props['org.ofono.NetworkRegistration']:
                 if self.ofono_interface_props['org.ofono.NetworkRegistration']['Status'].value == 'registered' or self.ofono_interface_props['org.ofono.NetworkRegistration']['Status'].value == 'roaming':
-                    self.props['state'] = Variant('u', 9) # registered MM_MODEM_STATE_REGISTERED
+                    self.props['state'] = Variant('u', ModemManagerState.REGISTERED)
                 elif self.ofono_interface_props['org.ofono.NetworkRegistration']['Status'].value == 'searching':
-                    self.props['state'] = Variant('u', 8) # searching MM_MODEM_STATE_SEARCHING
+                    self.props['state'] = Variant('u', ModemManagerState.SEARCHING)
                 else:
-                    self.props['state'] = Variant('u', 7) # enabled MM_MODEM_STATE_ENABLED
+                    self.props['state'] = Variant('u', ModemManagerState.ENABLED)
 
             if 'Status' in self.ofono_interface_props['org.ofono.NetworkRegistration']:
                 if self.ofono_interface_props['org.ofono.NetworkRegistration']['Status'].value == "unregistered":
@@ -69,25 +71,25 @@ class MMModemSimpleInterface(ServiceInterface):
             self.props['m3gpp-operator-name'] = Variant('s', '')
             self.props['m3gpp-operator-code'] = Variant('s', '')
             self.props['signal-quality'] = Variant('(ub)', [0, True])
-            self.props['state'] = Variant('u', 7) # enabled MM_MODEM_STATE_ENABLED
+            self.props['state'] = Variant('u', ModemManagerState.ENABLED)
 
         if 'org.ofono.NetworkRegistration' in self.ofono_interface_props and self.props['state'].value == 7:
             if "Technology" in self.ofono_interface_props['org.ofono.NetworkRegistration']:
                 current_tech = 0
                 if self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "nr":
-                    current_tech |= 1 << 15 # network is 5g MM_MODEM_ACCESS_TECHNOLOGY_5GNR
+                    current_tech |= 1 << ModemManagerAccessTechnology._5GNR
                 elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "lte":
-                    current_tech |= 1 << 14 # network is lte MM_MODEM_ACCESS_TECHNOLOGY_LTE
+                    current_tech |= 1 << ModemManagerAccessTechnology.LTE
                 elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "umts" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hspa" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsdpa" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "hsupa":
-                    current_tech |= 1 << 5 # network is umts MM_MODEM_ACCESS_TECHNOLOGY_UMTS
+                    current_tech |= 1 << ModemManagerAccessTechnology.UMTS
                 elif self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gsm" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "edge" or self.ofono_interface_props['org.ofono.NetworkRegistration']["Technology"].value == "gprs":
-                    current_tech |= 1 << 1 # network is gsm MM_MODEM_ACCESS_TECHNOLOGY_GSM
+                    current_tech |= 1 << ModemManagerAccessTechnology.GSM
 
                 self.props['access-technologies'] = Variant('u', current_tech)
             else:
-                self.props['access-technologies'] = Variant('u', 0) # network is unknown MM_MODEM_ACCESS_TECHNOLOGY_UNKNOWN
+                self.props['access-technologies'] = Variant('u', ModemManagerAccessTechnology.UNKNOWN)
         else:
-            self.props['access-technologies'] = Variant('u', 0) # network is unknown MM_MODEM_ACCESS_TECHNOLOGY_UNKNOWN
+            self.props['access-technologies'] = Variant('u', ModemManagerAccessTechnology.UNKNOWN)
 
     @method()
     async def Connect(self, properties: 'a{sv}') -> 'o':

--- a/ofono2mm/mm_types.py
+++ b/ofono2mm/mm_types.py
@@ -220,3 +220,14 @@ MM_MODES = {
     ],
     ModemManagerMode.NONE: []
 }
+
+class ModemManagerPortType:
+    UNKNOWN = 1
+    NET     = 2
+    AT      = 3
+    QCDM    = 4
+    GPS     = 5
+    QMI     = 6
+    MBIM    = 7
+    AUDIO   = 8
+    IGNORED = 9

--- a/ofono2mm/mm_types.py
+++ b/ofono2mm/mm_types.py
@@ -1,0 +1,222 @@
+
+class ModemManagerState:
+    FAILED        = -1
+    UNKNOWN       = 0
+    INITIALIZING  = 1
+    LOCKED        = 2
+    DISABLED      = 3
+    DISABLING     = 4
+    ENABLING      = 5
+    ENABLED       = 6
+    SEARCHING     = 7
+    REGISTERED    = 8
+    DISCONNECTING = 9
+    CONNECTING    = 10
+    CONNECTED     = 11
+
+    def to_string(value):
+        match value:
+            case ModemManagerState.FAILED:
+                return "Failed"
+            case ModemManagerState.UNKNOWN:
+                return "Unknown"
+            case ModemManagerState.INITIALIZING:
+                return "Initializing"
+            case ModemManagerState.LOCKED:
+                return "Locked"
+            case ModemManagerState.DISABLED:
+                return "Disabled"
+            case ModemManagerState.DISABLING:
+                return "Disabling"
+            case ModemManagerState.ENABLING:
+                return "Enabling"
+            case ModemManagerState.ENABLED:
+                return "Enabled"
+            case ModemManagerState.SEARCHING:
+                return "Searching"
+            case ModemManagerState.REGISTERED:
+                return "Registered"
+            case ModemManagerState.DISCONNECTING:
+                return "Disconnecting"
+            case ModemManagerState.CONNECTING:
+                return "Connecting"
+            case _:
+                return "Connected"
+
+class ModemManagerStateFailedReason:
+    NONE                  = 0
+    UNKNOWN               = 1
+    SIM_MISSING           = 2
+    SIM_ERROR             = 3
+    UNKNOWN_CAPABILITIES  = 4
+    ESIM_WITHOUT_PROFILES = 5
+
+class ModemManagerLock:
+    UNKNOWN        = 0
+    NONE           = 1
+    SIM_PIN        = 2
+    SIM_PIN2       = 3
+    SIM_PUK        = 4
+    SIM_PUK2       = 5
+    PH_SP_PIN      = 6
+    PH_SP_PUK      = 7
+    PH_NET_PIN     = 8
+    PH_NET_PUK     = 9
+    PH_SIM_PIN     = 10
+    PH_CORP_PIN    = 11
+    PH_CORP_PUK    = 12
+    PH_FSIM_PIN    = 13
+    PH_FSIM_PUK    = 14
+    PH_NETSUB_PIN  = 15
+    PH_NETSUB_PUK  = 16
+
+OFONO_RETRIES_LOCK = {
+    'pin' : ModemManagerLock.SIM_PIN,
+    'pin2': ModemManagerLock.SIM_PIN2,
+    'puk': ModemManagerLock.SIM_PUK,
+    'puk2': ModemManagerLock.SIM_PUK2,
+    'service': ModemManagerLock.PH_SP_PIN,
+    'servicepuk': ModemManagerLock.PH_SP_PUK,
+    'network': ModemManagerLock.PH_NET_PIN,
+    'networkpuk': ModemManagerLock.PH_NET_PUK,
+    'corp': ModemManagerLock.PH_CORP_PIN,
+    'corppuk': ModemManagerLock.PH_CORP_PUK,
+    'netsub': ModemManagerLock.PH_NETSUB_PIN,
+    'netsubpuk': ModemManagerLock.PH_NETSUB_PUK,
+}
+
+class ModemManagerAccessTechnology:
+    UNKNOWN     = 0
+    POTS        = 1 << 0
+    GSM         = 1 << 1
+    GSM_COMPACT = 1 << 2
+    GPRS        = 1 << 3
+    EDGE        = 1 << 4
+    UMTS        = 1 << 5
+    HSDPA       = 1 << 6
+    HSUPA       = 1 << 7
+    HSPA        = 1 << 8
+    HSPA_PLUS   = 1 << 9
+    _1XRTT      = 1 << 10
+    EVDO0       = 1 << 11
+    EVDOA       = 1 << 12
+    EVDOB       = 1 << 13
+    LTE         = 1 << 14
+    _5GNR       = 1 << 15
+    LTE_CAT_M   = 1 << 16
+    LTE_NB_IOT  = 1 << 17
+    ANY         = 0xFFFFFFFF
+
+class ModemManagerCellType:
+    UNKNOWN = 0
+    CDMA    = 1
+    GSM     = 2
+    UMTS    = 3
+    TDSCDMA = 4
+    LTE     = 5
+    _5GNR   = 6
+
+OFONO_TECHNOLOGIES = {
+    "nr": ModemManagerAccessTechnology._5GNR,
+    "lte": ModemManagerAccessTechnology.LTE,
+    "hspa": ModemManagerAccessTechnology.HSPA,
+    "hsupa": ModemManagerAccessTechnology.HSUPA,
+    "hsdpa": ModemManagerAccessTechnology.HSDPA,
+    "umts": ModemManagerAccessTechnology.UMTS,
+    "edge": ModemManagerAccessTechnology.GSM,
+    "gprs": ModemManagerAccessTechnology.GSM,
+    "gsm": ModemManagerAccessTechnology.GSM
+}
+
+OFONO_CELL_TYPES = {
+    "nr": ModemManagerCellType._5GNR,
+    "lte": ModemManagerCellType.LTE,
+    "hspa": ModemManagerCellType.UMTS,
+    "hsupa": ModemManagerCellType.UMTS,
+    "hsdpa": ModemManagerCellType.UMTS,
+    "umts": ModemManagerCellType.UMTS,
+    "edge": ModemManagerCellType.GSM,
+    "gprs": ModemManagerCellType.GSM,
+    "gsm": ModemManagerCellType.GSM
+}
+
+class ModemManagerMode:
+    NONE = 0
+    CS   = 1 << 0
+    _2G  = 1 << 1
+    _3G  = 1 << 2
+    _4G  = 1 << 3
+    _5G  = 1 << 4
+    ANY  = 0xFFFFFFFF
+
+class ModemManagerCapability:
+    NONE         = 0
+    POTS         = 1 << 0
+    CDMA_EVDO    = 1 << 1
+    GSM_UMTS     = 1 << 2
+    LTE          = 1 << 3
+    IRIDIUM      = 1 << 5
+    _5GNR        = 1 << 6
+    TDS          = 1 << 7
+    ANY          = 0xFFFFFFFF
+
+OFONO_MODES = {
+    "gsm": ModemManagerMode._2G,
+    "umts": ModemManagerMode._3G,
+    "lte": ModemManagerMode._4G,
+    "nr": ModemManagerMode._5G
+}
+
+OFONO_CAPS = {
+    "gsm": ModemManagerCapability.GSM_UMTS,
+    "umts": ModemManagerCapability.GSM_UMTS,
+    "lte": ModemManagerCapability.LTE,
+    "nr": ModemManagerCapability._5GNR
+}
+
+MM_MODES = {
+    ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G: [
+        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode._5G],
+        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
+        [ModemManagerMode._2G | ModemManagerMode._3G, ModemManagerMode._3G],
+        [ModemManagerMode._2G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G: [
+        [ModemManagerMode._3G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._2G | ModemManagerMode._4G | ModemManagerMode._5G: [
+        [ModemManagerMode._2G | ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._4G | ModemManagerMode._5G: [
+        [ModemManagerMode._4G | ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._3G | ModemManagerMode._5G: [
+        [ModemManagerMode._3G | ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._2G | ModemManagerMode._5G: [
+        [ModemManagerMode._2G | ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._5G: [
+        [ModemManagerMode._5G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G: [
+        [ModemManagerMode._2G | ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
+        [ModemManagerMode._2G | ModemManagerMode._3G, ModemManagerMode._3G],
+        [ModemManagerMode._2G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._3G | ModemManagerMode._4G: [
+        [ModemManagerMode._3G | ModemManagerMode._4G, ModemManagerMode._4G],
+        [ModemManagerMode._3G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._2G | ModemManagerMode._4G: [
+        [ModemManagerMode._2G | ModemManagerMode._4G, ModemManagerMode._4G],
+        [ModemManagerMode._2G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._3G: [
+        [ModemManagerMode._3G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode._2G: [
+        [ModemManagerMode._2G, ModemManagerMode.ANY]
+    ],
+    ModemManagerMode.NONE: []
+}


### PR DESCRIPTION
```
2a7bde6826a8a755c1f6adc6df2a43b9d8374420 mm_modem_simple: Use ModemManagerState and ModemManagerAccessTechnology
ee2132eb559653b765c8378fd2564bc97963dcdf mm_types: Add ModemManagerPortType
f7ac4e54ab1ea888d42e565223b4267249499b58 mm_modem: Move common types to own file
```

There is something strange in this commits:

In ee2132eb559653b765c8378fd2564bc97963dcdf, MM_MODEM_PORT_TYPE_AT value was wrong, 2 instead of 3: https://github.com/linux-mobile-broadband/ModemManager/blob/main/include/ModemManager-enums.h#L669

In 2a7bde6826a8a755c1f6adc6df2a43b9d8374420, all modem state values were wrong:
- Enabled is 6, not 7
- Searching is 7 not 8
- Registered is 8, not 9

I'm testing this for some days, for now it works...