### PR TITLE
mm_modem: Properly set and update bearer properties

### DIFF
--- a/ofono2mm/mm_bearer.py
+++ b/ofono2mm/mm_bearer.py
@@ -3,15 +3,17 @@ from dbus_next.service import (ServiceInterface,
 from dbus_next.constants import PropertyAccess
 from dbus_next import Variant, DBusError, BusType
 
-from ofono2mm.mm_types import ModemManagerPortType
+from ofono2mm.mm_types import ModemManagerPortType, ModemManagerState
 from ofono2mm.utils import async_retryable
+from ofono2mm.logger import Logger
 
 import asyncio
+from time import time
 
 class MMBearerInterface(ServiceInterface):
     def __init__(self, index, bus, ofono_client, modem_name, ofono_modem, ofono_props, ofono_interfaces, ofono_interface_props, mm_modem):
         super().__init__('org.freedesktop.ModemManager1.Bearer')
-        # print(f"Creating new bearer interface for {index}")
+        Logger.info(f"Creating new bearer interface for {index}")
         self.index = index
         self.bus = bus
         self.ofono_client = ofono_client
@@ -21,9 +23,10 @@ class MMBearerInterface(ServiceInterface):
         self.ofono_props = ofono_props
         self.ofono_interfaces = ofono_interfaces
         self.ofono_interface_props = ofono_interface_props
+        self.ofono_ctx = None
         self.mm_modem = mm_modem
-        self.disconnecting = False
-        self.reconnect_task = None
+        self.connect_timestamp = 0
+        self.props_synced = False
         self.props = {
             "Interface": Variant('s', ''),
             "Connected": Variant('b', False),
@@ -118,10 +121,6 @@ class MMBearerInterface(ServiceInterface):
                         chosen_password = password
                         chosen_ctx_path = ctx[0]
 
-            self.props['Properties'].value['apn'] = Variant('s', chosen_apn if chosen_apn != '' else '')
-            self.props['Properties'].value['user'] = Variant('s', chosen_username if chosen_username != '' else '')
-            self.props['Properties'].value['password'] = Variant('s', chosen_password if chosen_password != '' else '')
-
             if chosen_auth_method == 'none':
                 self.props['Properties'].value['allowed-auth'] = Variant('u', 1) # none MM_BEARER_ALLOWED_AUTH_NONE
             elif chosen_auth_method == 'pap':
@@ -144,51 +143,103 @@ class MMBearerInterface(ServiceInterface):
                 elif roaming_allowed == False:
                     self.props['Properties'].value['roaming-allowance'] = Variant('u', 0) # roaming none MM_BEARER_ROAMING_ALLOWANCE_NONE
 
+    def update_properties(self, properties):
+        old_properties = self.props['Properties'].value
+        old_user = old_properties['user'].value if 'user' in old_properties else ''
+        old_password = old_properties['password'].value if 'password' in old_properties else ''
+        user = properties['user'].value if 'user' in properties else ''
+        password = properties['password'].value if 'password' in properties else ''
+
+        if self.props_synced:
+            self.props_synced = properties['apn'] == old_properties['apn'] and \
+                                old_user == user and old_password == password
+
+        self.props['Properties'].value = Variant('a{sv}', properties)
+
+    def set_context(self, ofono_ctx):
+        self.ofono_ctx = ofono_ctx
+        ofono_ctx_interface = self.ofono_client['ofono_context'][ofono_ctx]['org.ofono.ConnectionContext']
+        ofono_ctx_interface.on_property_changed(self.ofono_context_changed)
+
+    async def update_context(self):
+        if 'org.ofono.ConnectionManager' not in self.ofono_interfaces:
+            return
+        properties = self.props['Properties'].value
+        ofono_ctx_interface = self.ofono_client['ofono_context'][self.ofono_ctx]['org.ofono.ConnectionContext']
+        try:
+            await ofono_ctx_interface.call_set_property('Active', Variant('b', False))
+        except Exception as e:
+            Logger.warning("Can't disable ofono context: %s", e)
+
+        try:
+            if 'apn' in properties:
+                await ofono_ctx_interface.call_set_property("Name", properties['apn'])
+                await ofono_ctx_interface.call_set_property("AccessPointName", properties['apn'])
+            await ofono_ctx_interface.call_set_property("Protocol", Variant('s', 'ip'))
+            await self.add_auth_ofono(properties['user'].value if 'user' in properties else '',
+                                      properties['password'].value if 'password' in properties else '')
+            self.props_synced = True
+        except Exception as e:
+            Logger.error("Can't update ofono context: %s", e)
+
+    async def wait_for_connect(self, timestamp):
+        while not self.props['Connected'].value and \
+                self.mm_modem.props['State'].value >= ModemManagerState.REGISTERED and \
+                self.connect_timestamp == timestamp:
+            await asyncio.sleep(1)
+
     @method()
     async def Connect(self):
-        await self.doConnect()
+        try:
+            await self.doConnect()
+        except Exception as e:
+            Logger.error("Error while connecting bearer: %s", e)
 
     @async_retryable()
     async def doConnect(self):
+        self.connect_timestamp = time()
+
         try:
             await self.set_props()
         except Exception as e:
             pass
 
-        # print("Do connect")
-        ofono_ctx_interface = self.ofono_client["ofono_context"][self.ofono_ctx]['org.ofono.ConnectionContext']
-        await ofono_ctx_interface.call_set_property("Active", Variant('b', True))
+        if not self.props_synced:
+            await self.update_context()
 
-        # Clear the reconnection task
-        self.reconnect_task = None
+        if self.props['Connected'].value:
+            return
+
+        timestamp = self.connect_timestamp
+        while self.connect_timestamp == timestamp:
+            ofono_ctx_interface = self.ofono_client['ofono_context'][self.ofono_ctx]['org.ofono.ConnectionContext']
+            try:
+                await ofono_ctx_interface.call_set_property("Active", Variant('b', True))
+                await self.wait_for_connect(timestamp)
+                break
+            except Exception as e:
+                Logger.warning("Connection failed: %s", e)
+                if self.mm_modem.props['State'].value < ModemManagerState.REGISTERED:
+                    break
+                if str(e) == 'Operation already in progress':
+                    await self.wait_for_connect(timestamp)
+                    break
+                await ofono_ctx_interface.call_set_property("Active", Variant('b', False))
+                await asyncio.sleep(10)
 
     @method()
     async def Disconnect(self):
         await self.doDisconnect()
 
-    async def cancel_reconnect_task(self):
-        if self.reconnect_task is not None:
-            self.reconnect_task.cancel()
-            try:
-                await self.reconnect_task
-            except asyncio.CancelledError:
-                # Finally
-                pass
-            finally:
-                self.reconnect_task = None
-
     async def doDisconnect(self):
-        self.disconnecting = True
-
-        # Cancel an eventual reconnection task
-        await self.cancel_reconnect_task()
+        self.connect_timestamp = time()
 
         ofono_ctx_interface = self.ofono_client["ofono_context"][self.ofono_ctx]['org.ofono.ConnectionContext']
         await ofono_ctx_interface.call_set_property("Active", Variant('b', False))
 
     async def add_auth_ofono(self, username, password):
-        ofono_ctx_interface = self.ofono_client["ofono_context"][self.ofono_ctx]['org.ofono.ConnectionContext']
         try:
+            ofono_ctx_interface = self.ofono_client["ofono_context"][self.ofono_ctx]['org.ofono.ConnectionContext']
             await ofono_ctx_interface.call_set_property("Username", Variant('s', username))
             await ofono_ctx_interface.call_set_property("Password", Variant('s', password))
         except Exception as e:
@@ -196,13 +247,9 @@ class MMBearerInterface(ServiceInterface):
 
     def ofono_context_changed(self, propname, value):
         if propname == "Active":
-            if self.disconnecting and (not value.value):
-                self.disconnecting = False
-            elif not self.disconnecting and (not value.value) and self.reconnect_task is None and self.props['Connected'].value:
-                self.reconnect_task = asyncio.create_task(self.doConnect())
-
             self.props['Connected'] = value
             self.emit_properties_changed({'Connected': value.value})
+            self.mm_modem.set_props()
         elif propname == "Settings":
             if 'Interface' in value.value:
                 self.props['Interface'] = value.value['Interface']

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -616,13 +616,14 @@ class MMModemInterface(ServiceInterface):
         await ofono_ctx_interface.call_set_property("Protocol", Variant('s', 'ip'))
         mm_bearer_interface.ofono_ctx = ofono_ctx
         ofono_ctx_interface.on_property_changed(self.ofono_context_changed)
-        self.bus.export(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}', mm_bearer_interface)
-        self.props['Bearers'].value.append(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}')
-        self.bearers[f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'] = mm_bearer_interface
+        bearer_path = f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'
+        self.bus.export(bearer_path, mm_bearer_interface)
+        self.props['Bearers'].value.append(bearer_path)
+        self.bearers[bearer_path] = mm_bearer_interface
         self.emit_properties_changed({'Bearers': self.props['Bearers'].value})
         bearer_i += 1
 
-        return f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'
+        return bearer_path
 
     @method()
     async def DeleteBearer(self, path: 'o'):

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -100,8 +100,6 @@ class MMModemInterface(ServiceInterface):
         for iface in self.ofono_props['Interfaces'].value:
             await self.add_ofono_interface(iface)
 
-        await self.check_ofono_contexts()
-
     async def add_ofono_interface(self, iface):
         self.ofono_interfaces.update({
             iface: self.ofono_proxy[iface]
@@ -161,6 +159,7 @@ class MMModemInterface(ServiceInterface):
         self.mm_sim_interface = MMSimInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props)
         self.bus.export(f'/org/freedesktop/ModemManager/SIM/{self.index}', self.mm_sim_interface)
         self.mm_sim_interface.set_props()
+        await self.check_ofono_contexts()
 
     async def init_mm_3gpp_interface(self):
         self.mm_modem3gpp_interface = MMModem3gppInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props)
@@ -230,6 +229,9 @@ class MMModemInterface(ServiceInterface):
     async def check_ofono_contexts(self):
         global bearer_i
         if not 'org.ofono.ConnectionManager' in self.ofono_interfaces:
+            return
+
+        if self.mm_sim_interface is None or not self.mm_sim_interface.present or self.mm_sim_interface.locked:
             return
 
         contexts = await self.ofono_interfaces['org.ofono.ConnectionManager'].call_get_contexts();

--- a/ofono2mm/mm_modem.py
+++ b/ofono2mm/mm_modem.py
@@ -138,7 +138,8 @@ class MMModemInterface(ServiceInterface):
             self.mm_modem_messaging_interface.set_props()
             await self.mm_modem_messaging_interface.init_messages()
         if iface == "org.ofono.ConnectionManager":
-            await self.check_ofono_contexts()
+            for bearer in self.bearers.values():
+                await self.set_bearer_context(bearer)
 
     async def remove_ofono_interface(self, iface):
         if iface in self.ofono_interfaces:
@@ -238,6 +239,8 @@ class MMModemInterface(ServiceInterface):
         old_bearer_list = self.props['Bearers'].value
         for ctx in contexts:
             if ctx[1]['Type'].value == "internet":
+                if self.get_bearer_path_for_apn(ctx[1]['AccessPointName'].value) is not None:
+                    continue
                 mm_bearer_interface = MMBearerInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props, self)
 
                 ip_method = 0
@@ -279,9 +282,8 @@ class MMModemInterface(ServiceInterface):
                     self.emit_properties_changed({'Ports': self.props['Ports'].value})
 
                 ofono_ctx_interface = self.ofono_client["ofono_context"][ctx[0]]["org.ofono.ConnectionContext"]
-                ofono_ctx_interface.on_property_changed(mm_bearer_interface.ofono_context_changed)
                 ofono_ctx_interface.on_property_changed(self.ofono_context_changed)
-                mm_bearer_interface.ofono_ctx = ctx[0]
+                mm_bearer_interface.set_context(ctx[0])
                 self.bus.export(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}', mm_bearer_interface)
                 self.props['Bearers'].value.append(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}')
                 self.bearers[f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'] = mm_bearer_interface
@@ -336,9 +338,8 @@ class MMModemInterface(ServiceInterface):
                 self.emit_properties_changed({'Ports': self.props['Ports'].value})
 
             ofono_ctx_interface = self.ofono_client["ofono_context"][path]['org.ofono.ConnectionContext']
-            ofono_ctx_interface.on_property_changed(mm_bearer_interface.ofono_context_changed)
             ofono_ctx_interface.on_property_changed(self.ofono_context_changed)
-            mm_bearer_interface.ofono_ctx = path
+            mm_bearer_interface.set_context(path)
             self.bus.export(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}', mm_bearer_interface)
             self.props['Bearers'].value.append(f'/org/freedesktop/ModemManager/Bearer/{bearer_i}')
             self.bearers[f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'] = mm_bearer_interface
@@ -531,15 +532,47 @@ class MMModemInterface(ServiceInterface):
 
         self.emit_properties_changed(changed_props)
 
+    async def get_internet_context(self):
+        if 'org.ofono.ConnectionManager' not in self.ofono_interfaces:
+            return None, None
+
+        contexts = await self.ofono_interfaces['org.ofono.ConnectionManager'].call_get_contexts()
+
+        for context in contexts:
+            name = context[1].get('Type', Variant('s', '')).value
+            access_point_name = context[1].get('AccessPointName', Variant('s', '')).value
+            if name.lower() == "internet":
+                if access_point_name:
+                     return (context[0], access_point_name)
+        return None, None
+
+    async def set_bearer_context(self, bearer_interface):
+        if 'org.ofono.ConnectionManager' not in self.ofono_interfaces or \
+                bearer_interface.ofono_ctx is not None:
+            return
+
+        (context_path, access_point_name) = await self.get_internet_context()
+
+        try:
+            if context_path is None:
+                context_path = await self.ofono_interfaces['org.ofono.ConnectionManager'].call_add_context("internet")
+        except Exception as e:
+            Logger.error("Failed to add an internet context: %s", e)
+            return
+
+        ofono_ctx_interface = self.ofono_client["ofono_context"][context_path]['org.ofono.ConnectionContext']
+        bearer_interface.set_context(context_path)
+
+    def get_bearer_path_for_apn(self, apn):
+        for b in self.bearers:
+            if self.bearers[b].props['Properties'].value['apn'].value == apn:
+                return b
+        return None
+
     @method()
     async def Enable(self, enable: 'b'):
         if self.props['State'].value == -1:
             return
-
-        old_state = self.props['State'].value
-        self.props['State'] = Variant('i', 6 if enable else 3)
-        self.StateChanged(old_state, self.props['State'].value, 1)
-        self.emit_properties_changed({'State': self.props['State'].value})
 
         try:
             await self.ofono_modem.call_set_property('Online', Variant('b', enable))
@@ -561,61 +594,11 @@ class MMModemInterface(ServiceInterface):
 
     async def doCreateBearer(self, properties):
         global bearer_i
-        connection_manager_tries = 0
 
-        # Prevents initial modem connection to fail by waiting for ofono
-        while 'org.ofono.ConnectionManager' not in self.ofono_interfaces and connection_manager_tries < 10:
-            await asyncio.sleep(1)
-            connection_manager_tries += 1
-
-        if 'org.ofono.ConnectionManager' not in self.ofono_interfaces:
-            return
-
-        Logger.debug(f"docreatebearer {bearer_i}")
         mm_bearer_interface = MMBearerInterface(self.index, self.bus, self.ofono_client, self.modem_name, self.ofono_modem, self.ofono_props, self.ofono_interfaces, self.ofono_interface_props, self)
-        mm_bearer_interface.props.update({
-            "Properties": Variant('a{sv}', properties)
-        })
 
-        # users would usually have to do
-        # set-context-property 0 AccessPointName example.apn && activate-context 1
-        # to activate the correct context for ofono2mm to use, lets do it on bearer creation to not need ofono scripts
-        contexts = await self.ofono_interfaces['org.ofono.ConnectionManager'].call_get_contexts()
-        self.context_names = []
-        ctx_idx = 0
-        chosen_apn = None
-        chosen_ctx_path = None
-        for ctx in contexts:
-            name = ctx[1].get('Type', Variant('s', '')).value
-            access_point_name = ctx[1].get('AccessPointName', Variant('s', '')).value
-            if name.lower() == "internet":
-                ctx_idx += 1
-                if access_point_name:
-                    self.context_names.append(access_point_name)
-                    chosen_apn = access_point_name
-                    chosen_ctx_path = ctx[0]
+        await self.set_bearer_context(mm_bearer_interface)
 
-                    # print(chosen_ctx_path)
-
-            if chosen_ctx_path:
-                # print("set apn")
-                chosen_ctx_interface = self.ofono_client["ofono_context"][chosen_ctx_path]['org.ofono.ConnectionContext']
-                await chosen_ctx_interface.call_set_property("Active", Variant('b', False))
-                await chosen_ctx_interface.call_set_property("AccessPointName", Variant('s', chosen_apn))
-                await chosen_ctx_interface.call_set_property("Protocol", Variant('s', 'ip'))
-                await chosen_ctx_interface.call_set_property("Active", Variant('b', True))
-
-        ofono_ctx = await self.ofono_interfaces['org.ofono.ConnectionManager'].call_add_context("internet")
-        ofono_ctx_interface = self.ofono_client["ofono_context"][ofono_ctx]['org.ofono.ConnectionContext']
-        if 'apn' in properties:
-            await ofono_ctx_interface.call_set_property("AccessPointName", properties['apn'])
-
-        await mm_bearer_interface.add_auth_ofono(properties['username'].value if 'username' in properties else '',
-                                                        properties['password'].value if 'password' in properties else '')
-
-        await ofono_ctx_interface.call_set_property("Protocol", Variant('s', 'ip'))
-        mm_bearer_interface.ofono_ctx = ofono_ctx
-        ofono_ctx_interface.on_property_changed(self.ofono_context_changed)
         bearer_path = f'/org/freedesktop/ModemManager/Bearer/{bearer_i}'
         self.bus.export(bearer_path, mm_bearer_interface)
         self.props['Bearers'].value.append(bearer_path)

--- a/ofono2mm/mm_modem_simple.py
+++ b/ofono2mm/mm_modem_simple.py
@@ -3,6 +3,9 @@ from dbus_next.constants import PropertyAccess
 from dbus_next import Variant
 
 from ofono2mm.mm_types import ModemManagerState, ModemManagerAccessTechnology
+from ofono2mm.logger import Logger
+
+import asyncio
 
 class MMModemSimpleInterface(ServiceInterface):
     def __init__(self, mm_modem, ofono_interfaces, ofono_interface_props):
@@ -98,33 +101,38 @@ class MMModemSimpleInterface(ServiceInterface):
         except Exception as e:
             pass
 
-        for b in self.mm_modem.bearers:
-            if self.mm_modem.bearers[b].props['Properties'].value['apn'] == properties['apn']:
-                await self.mm_modem.bearers[b].add_auth_ofono(properties['username'].value if 'username' in properties else '',
-                                                                properties['password'].value if 'password' in properties else '')
-                self.mm_modem.bearers[b].props['Properties'] = Variant('a{sv}', properties)
-                await self.mm_modem.bearers[b].doConnect()
-                return b
-
         try:
-            bearer = await self.mm_modem.doCreateBearer(properties)
-            await self.mm_modem.bearers[bearer].doConnect()
-        except Exception as e:
-            bearer = f'/org/freedesktop/ModemManager/Bearer/0'
+            path = self.mm_modem.get_bearer_path_for_apn(properties['apn'].value)
+            if path is None:
+                path = await self.mm_modem.doCreateBearer(properties)
 
-        return bearer
+            bearer = self.mm_modem.bearers[path]
+            bearer.update_properties(properties)
+
+            # From ModemManager documentation:
+            # this call may wait for network registration
+            while self.mm_modem.props['State'].value < ModemManagerState.REGISTERED:
+                await asyncio.sleep(1)
+
+            Logger.info('Using bearer %s for %s', path, properties['apn'].value)
+            await bearer.doConnect()
+        except Exception as e:
+            Logger.error("Error while connecting bearer: %s", e)
+
+        return path
 
     @method()
     async def Disconnect(self, path: 'o'):
         if path == '/':
-            for b in self.mm_modem.bearers:
+            for b in self.mm_modem.bearers.keys():
                 try:
                     await self.mm_modem.bearers[b].doDisconnect()
                 except Exception as e:
                     pass
-        if path in self.mm_modem.bearers:
+        if path in self.mm_modem.bearers.keys():
             try:
-                await self.mm_modem.bearers[path].doDisconnect()
+                if self.mm_modem.bearers.props['Connected'].value:
+                   await self.mm_modem.bearers[path].doDisconnect()
             except Exception as e:
                 pass
 

--- a/ofono2mm/mm_sim.py
+++ b/ofono2mm/mm_sim.py
@@ -157,6 +157,32 @@ class MMSimInterface(ServiceInterface):
     def Removability(self) -> 'u':
         return self.props['Removability'].value
 
+    @property
+    def available(self):
+        return 'org.ofono.SimManager' in self.ofono_interfaces
+
+    @property
+    def present(self):
+        if not self.available:
+            return False
+
+        sim_manager = self.ofono_interface_props['org.ofono.SimManager']
+        if 'Present' not in sim_manager:
+            return False
+
+        return self.ofono_interface_props['org.ofono.SimManager']['Present'].value
+
+    @property
+    def locked(self):
+        if not self.available:
+            return False
+
+        sim_manager = self.ofono_interface_props['org.ofono.SimManager']
+        if 'PinRequired' not in sim_manager:
+            return False
+
+        return sim_manager['PinRequired'].value != 'none'
+
     def ofono_changed(self, name, varval):
         self.ofono_props[name] = varval
         self.set_props()


### PR DESCRIPTION
This PR enhances the reliability and correctness of bearer and modem initialization in mm_modem by addressing several critical areas:

* Proper Bearer Configuration
    Ensures bearer properties (APN, username, password, etc.) are correctly set and kept in sync across oFono, D-Bus, and ModemManager. Context setup is now handled asynchronously for cleaner and more efficient startup.

* Correct Bearer Path Export
    Fixes an issue where the returned bearer path did not match the actual D-Bus exported object, preventing mismatches and potential client-side errors.

* Robust SIM State Handling
    Adds logic to skip context setup if the SIM card is not present or is locked. New helper properties improve SIM state checks, increasing stability in multi-SIM environments.

